### PR TITLE
feat: load change log posts from airtable

### DIFF
--- a/change-log nashville
+++ b/change-log nashville
@@ -650,7 +650,7 @@
       padding: 0;
     }
     
-    /* Hide Substack elements */
+    /* Legacy Substack cleanup */
     .article-content .captioned-image-container figure::after,
     .article-content .button-wrapper,
     .article-content .subscription-widget-wrap-editor,
@@ -933,118 +933,31 @@
     // ================================================
     // Configuration:
     // 1. n8n webhook URL is already set
-    // 2. First 10 posts come from Substack RSS
+    // 2. First 10 posts come from Airtable
     // 3. After 10 posts, "View Archive" button appears
     // 4. Archive page shows all Airtable posts
     // 5. Test button commented out for production
     // ================================================
     
-    // Substack Content Processor
-    class SubstackContentProcessor {
-      constructor() {
-        this.removeSelectors = [
-          '.pencraft',
-          '.image-link-expand',
-          '.button-wrapper',
-          '.subscription-widget-wrap-editor',
-          'button[aria-label*="Refresh"]',
-          'button[title*="Refresh"]'
-        ];
-      }
-      
-      process(contentHTML) {
-        const wrapper = document.createElement('div');
-        wrapper.innerHTML = contentHTML;
-        
-        this.removeUnwantedElements(wrapper);
-        this.processImages(wrapper);
-        this.processFootnotes(wrapper);
-        this.cleanupEmpty(wrapper);
-        
-        return wrapper.innerHTML;
-      }
-      
-      removeUnwantedElements(root) {
-        this.removeSelectors.forEach(selector => {
-          root.querySelectorAll(selector).forEach(el => el.remove());
-        });
-      }
-      
-      processImages(root) {
-        root.querySelectorAll('img').forEach(img => {
-          img.style.maxWidth = '100%';
-          img.style.height = 'auto';
-        });
-      }
-      
-      processFootnotes(root) {
-        const footnoteAnchors = root.querySelectorAll('a.footnote-anchor');
-        footnoteAnchors.forEach((anchor, index) => {
-          const span = document.createElement('span');
-          span.className = 'footnote-number';
-          span.textContent = anchor.textContent;
-          anchor.parentNode.replaceChild(span, anchor);
-        });
-        
-        const backLinks = root.querySelectorAll('.footnote a[href*="footnote-anchor"]');
-        backLinks.forEach(link => link.remove());
-        
-        const footnotes = root.querySelectorAll('.footnote');
-        if (footnotes.length > 0) {
-          const footnotesSection = document.createElement('div');
-          footnotesSection.className = 'footnotes-section';
-          footnotesSection.innerHTML = '<hr class="footnotes-divider" />';
-          
-          footnotes.forEach((footnote, index) => {
-            const number = document.createElement('span');
-            number.className = 'footnote-label';
-            number.textContent = `${index + 1}. `;
-            
-            const content = footnote.querySelector('.footnote-content') || footnote;
-            content.prepend(number);
-            
-            footnotesSection.appendChild(footnote);
-          });
-          
-          root.appendChild(footnotesSection);
-        }
-      }
-      
-      cleanupEmpty(root) {
-        root.querySelectorAll('p').forEach(p => {
-          if (!p.textContent.trim() && !p.querySelector('img')) {
-            p.remove();
-          }
-        });
-      }
-    }
-    
-    // Integrated Feed Manager - First 10 from Substack, then Airtable via n8n
+    // Integrated Feed Manager - Airtable archive
     class IntegratedFeedManager {
       constructor() {
-        // Substack configuration
-        this.feedUrl = 'https://prometheoid.substack.com/feed';
-        this.apiUrl = 'https://api.rss2json.com/v1/api.json?rss_url=' + encodeURIComponent(this.feedUrl);
-        
-        // N8n webhook configuration
+        // Airtable webhook configuration
         this.n8nWebhookUrl = 'https://n8n.intelechia.com/webhook/change-log';
-        
-        this.processor = new SubstackContentProcessor();
+
         this.refreshBtn = document.getElementById('refresh-commits');
         this.loadMoreBtn = document.getElementById('load-more');
         this.testAirtableBtn = document.getElementById('test-airtable');
         this.backToMainBtn = document.getElementById('back-to-main');
-        
+
         // View state
         this.currentView = 'main'; // 'main' or 'archive'
-        
-        this.substackPosts = [];
-        this.airtablePosts = [];
-        this.displayedSubstack = 0;
-        this.displayedAirtable = 0;
+
+        this.posts = [];
+        this.displayedPosts = 0;
         this.postsPerLoad = 6;
-        this.maxSubstackDisplay = 10;
-        
+        this.maxDisplay = 10;
+
         this.init();
       }
       
@@ -1063,8 +976,7 @@
       }
       
       handleLoadMore() {
-        // If we've shown all Substack posts, go to archive view
-        if (this.displayedSubstack >= Math.min(this.substackPosts.length, this.maxSubstackDisplay)) {
+        if (this.displayedPosts >= Math.min(this.posts.length, this.maxDisplay)) {
           this.showArchiveView();
         } else {
           this.loadMorePosts();
@@ -1090,8 +1002,8 @@
         // Update archive stats
         const statsEl = document.getElementById('archive-stats');
         if (statsEl) {
-          const totalPosts = this.airtablePosts.length;
-          const dateRange = this.getDateRange(this.airtablePosts);
+          const totalPosts = this.posts.length;
+          const dateRange = this.getDateRange(this.posts);
           statsEl.innerHTML = `
             <strong>${totalPosts}</strong> archived posts
             ${dateRange ? `<span class="mx-2">•</span> ${dateRange}` : ''}
@@ -1105,11 +1017,11 @@
         // Use setTimeout to show loading state briefly
         setTimeout(() => {
           archiveContainer.innerHTML = '';
-          
-          if (this.airtablePosts.length === 0) {
+
+          if (this.posts.length === 0) {
             archiveContainer.innerHTML = '<p class="text-center text-gray-500 py-8">No archived posts available.</p>';
           } else {
-            this.airtablePosts.forEach((post, index) => {
+            this.posts.forEach((post, index) => {
               const card = this.createPostCard(post, index);
               archiveContainer.appendChild(card);
             });
@@ -1171,8 +1083,8 @@
             
             alert(`Success! Found ${transformed.length} Airtable records. Click "View Archive" after loading all recent posts to see them.`);
             
-            // Update the stored airtable posts
-            this.airtablePosts = transformed;
+            // Update the stored posts
+            this.posts = transformed;
             this.updateLoadMoreButton();
           } else {
             alert('Connection successful but no records found');
@@ -1187,104 +1099,26 @@
         this.showLoading();
         
         try {
-          const [substackPosts, airtablePosts] = await Promise.all([
-            this.fetchSubstackFeed(),
-            this.fetchAirtableRecords()
-          ]);
-          
-          this.substackPosts = substackPosts;
-          this.airtablePosts = airtablePosts;
-          
-          console.log(`Loaded ${this.substackPosts.length} posts from Substack`);
-          console.log(`Loaded ${this.airtablePosts.length} posts from Airtable`);
-          
-          this.displayedSubstack = 0;
-          this.displayedAirtable = 0;
+          this.posts = await this.fetchAirtableRecords();
+          console.log(`Loaded ${this.posts.length} posts from Airtable`);
+          this.displayedPosts = 0;
           this.renderInitialPosts();
         } catch (error) {
           console.error('Feed error:', error);
           this.showError(error.message);
         }
       }
-      
-      async fetchSubstackFeed() {
-        try {
-          const response = await fetch(this.apiUrl);
-          const data = await response.json();
-          
-          if (data.status !== 'ok') {
-            throw new Error(data.message || 'Failed to load Substack posts');
-          }
-          
-          return data.items.slice(0, this.maxSubstackDisplay).map(item => ({
-            ...item,
-            source: 'substack'
-          }));
-        } catch (error) {
-          console.error('Substack error:', error);
-          return [];
-        }
-      }
-      
+
       async fetchAirtableRecords() {
         try {
-          console.log('Fetching Airtable records from:', this.n8nWebhookUrl);
-          
-          // Try a simpler request first
-          const testResponse = await fetch(this.n8nWebhookUrl, {
-            method: 'GET',
-            mode: 'cors',
-            headers: {
-              'Accept': 'application/json'
-            }
-          });
-          
-          console.log('Test GET response:', testResponse.status);
-          
-          // Now try the POST request
-          const response = await fetch(this.n8nWebhookUrl, {
-            method: 'POST',
-            mode: 'cors',
-            headers: {
-              'Content-Type': 'application/json',
-              'Accept': 'application/json'
-            },
-            body: JSON.stringify({
-              action: 'fetchRecords',
-              maxRecords: 100,
-              sort: [{ field: 'Published', direction: 'desc' }]
-            })
-          });
-          
-          console.log('Airtable POST response status:', response.status);
-          
+          const response = await fetch(this.n8nWebhookUrl);
           if (!response.ok) {
-            const errorText = await response.text();
-            console.error('Webhook error response:', errorText);
-            throw new Error(`Webhook error: ${response.status} - ${errorText}`);
+            throw new Error(`Webhook error: ${response.status}`);
           }
-          
-          const text = await response.text();
-          console.log('Raw response (first 500 chars):', text.substring(0, 500));
-          
-          let data;
-          try {
-            data = JSON.parse(text);
-          } catch (e) {
-            console.error('Failed to parse response as JSON:', e);
-            throw new Error('Invalid JSON response from webhook');
-          }
-          
-          console.log('Parsed Airtable data:', data);
-          console.log('Data type:', Array.isArray(data) ? 'array' : typeof data);
-          
-          const transformedRecords = this.transformAirtableRecords(data);
-          console.log(`Transformed ${transformedRecords.length} records`);
-          
-          return transformedRecords;
+          const data = await response.json();
+          return this.transformAirtableRecords(data);
         } catch (error) {
           console.error('Error fetching from Airtable:', error);
-          // Return empty array instead of throwing to allow Substack to still work
           return [];
         }
       }
@@ -1302,13 +1136,13 @@
           // Map Airtable field names to expected format
           const transformed = {
             id: record.id || Math.random().toString(36).substr(2, 9),
-            title: record.Title || 'Untitled',
+            title: record.Title || record.Notes || 'Untitled',
             content: record.Excerpt || '',
             description: record.Excerpt || '',
             pubDate: record['ISO Date'] || record['Display Date'] || new Date().toISOString(),
             author: record.Authors || 'Staff',
             link: record.URL || '#',
-            categories: record.Tags ? (Array.isArray(record.Tags) ? record.Tags : [record.Tags]) : [],
+            categories: [],
             source: 'airtable',
             thumbnail: record['Preview Image URL'] || null
           };
@@ -1325,7 +1159,7 @@
         document.getElementById('featured-post').innerHTML = `
           <div class="loading-state">
             <div class="spinner"></div>
-            <p class="mt-3">Loading updates from multiple sources...</p>
+            <p class="mt-3">Loading updates from archive...</p>
           </div>
         `;
         document.getElementById('posts-grid').innerHTML = '';
@@ -1341,71 +1175,60 @@
       }
       
       renderInitialPosts() {
-        if (this.substackPosts.length === 0 && this.airtablePosts.length === 0) return;
-        
-        if (this.substackPosts.length > 0) {
-          this.renderFeaturedPost(this.substackPosts[0]);
-          this.displayedSubstack = 1;
-        } else if (this.airtablePosts.length > 0) {
-          this.renderFeaturedPost(this.airtablePosts[0]);
-          this.displayedAirtable = 1;
-        }
-        
+        if (this.posts.length === 0) return;
+
+        this.renderFeaturedPost(this.posts[0]);
+        this.displayedPosts = 1;
+
         // Clear grid before rendering
         document.getElementById('posts-grid').innerHTML = '';
-        
+
         // Hide archive elements in main view
         document.getElementById('archive-grid').style.display = 'none';
         document.getElementById('archive-divider').style.display = 'none';
-        
+
         this.renderNextBatch();
       }
-      
+
       renderNextBatch() {
         const gridContainer = document.getElementById('posts-grid');
-        
-        let postsToRender = [];
+
         let remainingSlots = this.postsPerLoad;
-        
-        // Only show Substack posts in main view
-        if (this.displayedSubstack < this.maxSubstackDisplay) {
-          const availableSubstack = this.substackPosts.slice(
-            this.displayedSubstack,
-            Math.min(this.displayedSubstack + remainingSlots, this.maxSubstackDisplay, this.substackPosts.length)
-          );
-          postsToRender.push(...availableSubstack);
-          this.displayedSubstack += availableSubstack.length;
-        }
-        
-        postsToRender.forEach((post, index) => {
+
+        const available = this.posts.slice(
+          this.displayedPosts,
+          Math.min(this.displayedPosts + remainingSlots, this.maxDisplay, this.posts.length)
+        );
+
+        available.forEach((post, index) => {
           const card = this.createPostCard(post, index);
           gridContainer.appendChild(card);
         });
-        
+
+        this.displayedPosts += available.length;
         this.updateLoadMoreButton();
       }
-      
+
       loadMorePosts() {
         const btn = document.getElementById('load-more');
         btn.classList.add('loading');
         btn.disabled = true;
-        
+
         setTimeout(() => {
           this.renderNextBatch();
           btn.classList.remove('loading');
           btn.disabled = false;
         }, 300);
       }
-      
+
       updateLoadMoreButton() {
         const btn = document.getElementById('load-more');
         const container = document.getElementById('load-more-container');
-        
-        const maxSubstackToShow = Math.min(this.substackPosts.length, this.maxSubstackDisplay);
-        
-        if (this.displayedSubstack >= maxSubstackToShow) {
-          // All Substack posts shown, show archive button
-          if (this.airtablePosts.length > 0) {
+
+        const maxToShow = Math.min(this.posts.length, this.maxDisplay);
+
+        if (this.displayedPosts >= maxToShow) {
+          if (this.posts.length > this.maxDisplay) {
             container.style.display = 'block';
             btn.innerHTML = `
               View Archive
@@ -1419,14 +1242,13 @@
           } else {
             container.innerHTML = `
               <p class="text-sm text-gray-500 font-medium">
-                You've reached the end • ${this.displayedSubstack} posts loaded
+                You've reached the end • ${this.displayedPosts} posts loaded
               </p>
             `;
           }
         } else {
-          // More Substack posts to show
           container.style.display = 'block';
-          const remaining = maxSubstackToShow - this.displayedSubstack;
+          const remaining = maxToShow - this.displayedPosts;
           btn.textContent = `Load More Stories (${remaining} remaining)`;
           btn.style.display = 'inline-block';
         }
@@ -1502,9 +1324,7 @@
         const modal = document.createElement('div');
         modal.className = 'modal';
         
-        const processedContent = item.source === 'substack' 
-          ? this.processor.process(item.content || item.description)
-          : item.content || item.description;
+        const processedContent = item.content || item.description;
         
         modal.innerHTML = `
           <div class="modal-header">
@@ -1536,9 +1356,9 @@
               ${item.author || 'Staff'} • ${new Date(item.pubDate).toLocaleDateString()}
               <span class="source-badge ${item.source}">${item.source}</span>
             </span>
-            ${item.link && item.link !== '#' ? 
+            ${item.link && item.link !== '#' ?
               `<a href="${item.link}" target="_blank" class="modal-link">
-                Read on ${item.source === 'substack' ? 'Substack' : 'original source'} →
+                Read original →
               </a>` : ''}
           </div>
         `;


### PR DESCRIPTION
## Summary
- replace Substack RSS feed with Airtable webhook
- map Airtable fields to changelog items and render them

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d6dc3a26c83329eb81930952ee77a