### PR TITLE
Refactor canvas collapse and zoom

### DIFF
--- a/node interaction canvas
+++ b/node interaction canvas
@@ -155,11 +155,11 @@
         .flow.collapsed {
             background: #1e1e1e;
             box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
-            padding: 0;
-            min-width: 120px;
-            width: 120px;
-            height: 120px;
-            display: flex;
+            padding: 4px 8px;
+            min-width: 0;
+            width: auto;
+            height: auto;
+            display: inline-flex;
             align-items: center;
             justify-content: center;
             border-radius: 12px;
@@ -170,30 +170,30 @@
             border: none;
             background: none;
             padding: 0;
-            width: 100%;
-            height: 100%;
+            width: auto;
+            height: auto;
             display: flex;
-            flex-direction: column;
+            flex-direction: row;
             align-items: center;
             justify-content: center;
         }
 
         .flow.collapsed .flow-label-container {
             display: flex;
-            flex-direction: column;
+            flex-direction: row;
             align-items: center;
             gap: 0;
         }
 
         .flow.collapsed .flow-label {
             display: block;
-            font-size: 10px;
+            font-size: 16px;
             text-align: center;
-            padding: 4px;
-            max-width: 100px;
+            padding: 0;
+            max-width: none;
             overflow: hidden;
             text-overflow: ellipsis;
-            color: #ccc;
+            color: #fff;
             cursor: default;
         }
 
@@ -202,8 +202,7 @@
         }
 
         .flow.collapsed .flow-icon {
-            font-size: 24px;
-            margin-bottom: 4px;
+            display: none;
         }
 
         .flow.collapsed .flow-content {
@@ -1415,20 +1414,26 @@
         }
         
         function handleWheel(e) {
-            e.preventDefault();
-            const delta = e.deltaY > 0 ? 0.9 : 1.1;
-            const newZoom = Math.max(0.1, Math.min(5, state.zoom * delta));
-            
-            const rect = state.canvas.getBoundingClientRect();
-            const x = e.clientX - rect.left;
-            const y = e.clientY - rect.top;
-            
-            state.panX = x - (x - state.panX) * (newZoom / state.zoom);
-            state.panY = y - (y - state.panY) * (newZoom / state.zoom);
-            
-           state.zoom = newZoom;
-           updateCanvasTransform();
-           updateZoomDisplay();
+            if (e.ctrlKey) {
+                e.preventDefault();
+                const delta = e.deltaY > 0 ? 0.9 : 1.1;
+                const newZoom = Math.max(0.1, Math.min(5, state.zoom * delta));
+
+                const rect = state.canvas.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+
+                state.panX = x - (x - state.panX) * (newZoom / state.zoom);
+                state.panY = y - (y - state.panY) * (newZoom / state.zoom);
+                state.zoom = newZoom;
+                updateZoomDisplay();
+            } else {
+                e.preventDefault();
+                state.panX -= e.deltaX;
+                state.panY -= e.deltaY;
+            }
+
+            updateCanvasTransform();
             scheduleUpdate(() => {
                 updateAllConnections();
                 updateMinimap();
@@ -1582,6 +1587,18 @@
             } else if (e.ctrlKey && e.key.toLowerCase() === 'v') {
                 e.preventDefault();
                 pasteFlows();
+            } else if (e.ctrlKey && (e.key === '+' || e.key === '=')) {
+                e.preventDefault();
+                App.zoomIn();
+            } else if (e.ctrlKey && e.key === '-') {
+                e.preventDefault();
+                App.zoomOut();
+            } else if (e.ctrlKey && e.key === '0') {
+                e.preventDefault();
+                App.resetZoom();
+            } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'l') {
+                e.preventDefault();
+                App.autoLayout();
             } else if (e.key.toLowerCase() === 'f') {
                 App.fitToContent();
             } else if (e.key === 'Tab' && state.activeConnection) {


### PR DESCRIPTION
## Summary
- Collapse flows to a compact label-only view
- Add pan/zoom handling for trackpads and keyboard zoom shortcuts
- Trigger auto layout via Ctrl+Shift+L

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688da8c417e08320af7513aba434b800