### PR TITLE
feat: add group filtering

### DIFF
--- a/node interaction canvas
+++ b/node interaction canvas
@@ -971,9 +971,9 @@
         }
 
         /* Role Filter Bar */
+        .group-filter-bar,
         .role-filter-bar {
             position: absolute;
-            top: 20px;
             right: 20px;
             background: rgba(26, 26, 26, 0.9);
             border: 1px solid rgba(255, 255, 255, 0.1);
@@ -986,6 +986,14 @@
             z-index: 1000;
         }
 
+        .group-filter-bar {
+            top: 20px;
+        }
+
+        .role-filter-bar {
+            top: 70px;
+        }
+
         .filter-label {
             font-size: 12px;
             color: #888;
@@ -993,14 +1001,16 @@
             letter-spacing: 0.5px;
         }
 
-        .role-chips {
+        .role-chips,
+        .group-chips {
             display: flex;
             gap: 8px;
             flex-wrap: wrap;
             max-width: 600px;
         }
 
-        .role-chip {
+        .role-chip,
+        .group-chip {
             background: #2a2a2a;
             border: 1px solid #3a3a3a;
             border-radius: 16px;
@@ -1012,18 +1022,21 @@
             white-space: nowrap;
         }
 
-        .role-chip:hover {
+        .role-chip:hover,
+        .group-chip:hover {
             background: #3a3a3a;
             border-color: #4a4a4a;
         }
 
-        .role-chip.active {
+        .role-chip.active,
+        .group-chip.active {
             background: #4a9eff;
             border-color: #3a8eef;
             color: #fff;
         }
 
-        .role-chip.active:hover {
+        .role-chip.active:hover,
+        .group-chip.active:hover {
             background: #3a8eef;
             border-color: #2a7edf;
         }
@@ -1144,6 +1157,15 @@
             <div class="minimap-viewport"></div>
         </div>
 
+        <div class="group-filter-bar">
+            <div class="filter-label">Filter by group:</div>
+            <div class="group-chips">
+                <div class="group-chip active" data-group="all" onclick="App.toggleGroupFilter('all')">
+                    All Groups
+                </div>
+            </div>
+        </div>
+
         <div class="role-filter-bar">
             <div class="filter-label">Filter by role:</div>
             <div class="role-chips">
@@ -1164,7 +1186,7 @@
             • Connect: drag from ▶ to ◀<br>
             • Change type: click operator symbol<br>
             • Rename: double-click label or click ✎<br>
-            • Filter by role to focus view<br>
+            • Filter by role or group to focus view<br>
             <hr>
             <strong>Shortcuts:</strong> [F] Fit • [R] Reset filter • [Delete] Remove
         </div>
@@ -1278,6 +1300,9 @@
             activeRoles: new Set(['all']),
             filterMode: 'highlight',
             availableRoles: new Set(),
+            // Group filtering
+            activeGroups: new Set(['all']),
+            availableGroups: new Set(),
         };
         
         // Sample data
@@ -1354,8 +1379,9 @@
             updateFlowIcon(flow3);
             updateRoleDisplay(flow3.nodes[0]);
             
-            // Update role filter after creating flows
+            // Update filters after creating flows
             updateAvailableRoles();
+            updateAvailableGroups();
             
             // Create a demo connection
             setTimeout(() => {
@@ -1798,6 +1824,7 @@
             
             // Update available roles when flow is populated
             updateAvailableRoles();
+            updateAvailableGroups();
         }
         
         function createNodeInFlow(flow, type, data) {
@@ -2390,6 +2417,14 @@
                         return true;
                     });
 
+                    if (state.groups.includes(item)) {
+                        item.items.forEach(it => {
+                            if (state.flows.includes(it) && it.groupId === item.id) {
+                                delete it.groupId;
+                            }
+                        });
+                    }
+
                     item.element.remove();
                     state.flows = state.flows.filter(f => f !== item);
                     state.groups = state.groups.filter(g => g !== item);
@@ -2398,6 +2433,7 @@
 
             state.selectedItems.clear();
             updateAvailableRoles(); // Update roles after deletion
+            updateAvailableGroups();
         }
 
         function serializeFlow(flow) {
@@ -2456,6 +2492,7 @@
                 updateFlowGrammar(flow);
             });
             updateAvailableRoles();
+            updateAvailableGroups();
         }
         
         // Modal
@@ -2594,6 +2631,28 @@
                 roleChips.appendChild(chip);
             });
         }
+
+        function updateAvailableGroups() {
+            state.availableGroups.clear();
+
+            const groupChips = document.querySelector('.group-chips');
+            if (!groupChips) return;
+
+            const allChip = groupChips.querySelector('[data-group="all"]');
+            groupChips.innerHTML = '';
+            groupChips.appendChild(allChip);
+
+            state.groups.forEach(group => {
+                state.availableGroups.add(group.id);
+                const chip = document.createElement('div');
+                chip.className = 'group-chip';
+                chip.setAttribute('data-group', group.id);
+                const header = group.element.querySelector('.group-header');
+                chip.textContent = header ? header.textContent.trim() : group.id;
+                chip.onclick = () => App.toggleGroupFilter(group.id);
+                groupChips.appendChild(chip);
+            });
+        }
         
         function getFlowRoles(flow) {
             const roles = new Set();
@@ -2671,6 +2730,81 @@
                 }
             }
         }
+
+        function applyGroupFilter() {
+            const statusEl = document.querySelector('.filter-status');
+
+            if (state.activeGroups.has('all')) {
+                state.flows.forEach(flow => {
+                    flow.element.classList.remove('dimmed', 'hidden', 'highlighted');
+                });
+                state.groups.forEach(group => {
+                    group.element.classList.remove('dimmed', 'hidden', 'highlighted');
+                });
+                state.connections.forEach(conn => {
+                    conn.group.classList.remove('dimmed', 'hidden');
+                });
+                if (statusEl) statusEl.textContent = '';
+                return;
+            }
+
+            let visibleCount = 0;
+            let totalCount = state.groups.length;
+
+            state.flows.forEach(flow => {
+                const inGroup = state.activeGroups.has(flow.groupId);
+                flow.element.classList.remove('dimmed', 'hidden', 'highlighted');
+
+                if (inGroup) {
+                    flow.element.classList.add('highlighted');
+                } else {
+                    if (state.filterMode === 'hide') {
+                        flow.element.classList.add('hidden');
+                    } else {
+                        flow.element.classList.add('dimmed');
+                    }
+                }
+            });
+
+            state.groups.forEach(group => {
+                const isActive = state.activeGroups.has(group.id);
+                group.element.classList.remove('dimmed', 'hidden', 'highlighted');
+                if (isActive) {
+                    group.element.classList.add('highlighted');
+                    visibleCount++;
+                } else {
+                    if (state.filterMode === 'hide') {
+                        group.element.classList.add('hidden');
+                    } else {
+                        group.element.classList.add('dimmed');
+                        visibleCount++;
+                    }
+                }
+            });
+
+            state.connections.forEach(conn => {
+                const outputVisible = !conn.outputOwner.element.classList.contains('hidden');
+                const inputVisible = !conn.inputOwner.element.classList.contains('hidden');
+                const outputDimmed = conn.outputOwner.element.classList.contains('dimmed');
+                const inputDimmed = conn.inputOwner.element.classList.contains('dimmed');
+
+                conn.group.classList.remove('dimmed', 'hidden');
+
+                if (!outputVisible || !inputVisible) {
+                    conn.group.classList.add('hidden');
+                } else if (outputDimmed && inputDimmed) {
+                    conn.group.classList.add('dimmed');
+                }
+            });
+
+            if (statusEl) {
+                if (state.filterMode === 'hide') {
+                    statusEl.textContent = `Showing ${visibleCount} of ${totalCount} groups`;
+                } else {
+                    statusEl.textContent = `${visibleCount} relevant groups`;
+                }
+            }
+        }
         
         // Export public functions
         App.createNewFlow = function() {
@@ -2705,6 +2839,7 @@
             populateFlow(flow);
             updateFlowIcon(flow);
             updateAvailableRoles(); // Update role filter when new flow is created
+            updateAvailableGroups();
             
             return flow;
         };
@@ -2846,6 +2981,7 @@
                 let itemRoles;
                 if (state.flows.includes(item)) {
                     itemRoles = getFlowRoles(item);
+                    item.groupId = group.id;
                 } else if (state.groups.includes(item)) {
                     itemRoles = new Set(item.roles);
                 } else {
@@ -2882,6 +3018,8 @@
 
             state.selectedItems.clear();
             document.querySelectorAll('.selected').forEach(el => el.classList.remove('selected'));
+
+            updateAvailableGroups();
         };
         
         App.exportAsText = function() {
@@ -2960,6 +3098,47 @@
             App.closeModal();
         };
         
+        App.toggleGroupFilter = function(groupId) {
+            const chip = document.querySelector(`[data-group="${groupId}"]`);
+            if (!chip) return;
+
+            if (groupId === 'all') {
+                state.activeGroups.clear();
+                state.activeGroups.add('all');
+                document.querySelectorAll('.group-chip').forEach(c => c.classList.remove('active'));
+                chip.classList.add('active');
+            } else {
+                if (state.activeGroups.has('all')) {
+                    state.activeGroups.clear();
+                }
+
+                if (state.activeGroups.has(groupId)) {
+                    state.activeGroups.delete(groupId);
+                    chip.classList.remove('active');
+                } else {
+                    state.activeGroups.add(groupId);
+                    chip.classList.add('active');
+                }
+
+                if (state.activeGroups.size === 0) {
+                    state.activeGroups.add('all');
+                    document.querySelector('[data-group="all"]').classList.add('active');
+                }
+
+                document.querySelector('[data-group="all"]').classList.remove('active');
+            }
+
+            applyGroupFilter();
+            if (!state.activeGroups.has('all')) {
+                state.activeRoles.clear();
+                state.activeRoles.add('all');
+                document.querySelectorAll('.role-chip').forEach(c => c.classList.remove('active'));
+                const allRole = document.querySelector('[data-role="all"]');
+                if (allRole) allRole.classList.add('active');
+            }
+            applyRoleFilter();
+        };
+
         App.toggleRoleFilter = function(role) {
             const chip = document.querySelector(`[data-role="${role}"]`);
             if (!chip) return;
@@ -2995,12 +3174,21 @@
             }
             
             applyRoleFilter();
+            if (!state.activeRoles.has('all')) {
+                state.activeGroups.clear();
+                state.activeGroups.add('all');
+                document.querySelectorAll('.group-chip').forEach(c => c.classList.remove('active'));
+                const allGroup = document.querySelector('[data-group="all"]');
+                if (allGroup) allGroup.classList.add('active');
+            }
+            applyGroupFilter();
         };
         
         App.updateFilterMode = function() {
             const mode = document.querySelector('input[name="filterMode"]:checked').value;
             state.filterMode = mode;
             applyRoleFilter();
+            applyGroupFilter();
         };
         
         // Initialize when DOM is ready


### PR DESCRIPTION
## Summary
- add a group filter bar and supporting styles for easier canvas navigation
- track group membership and expose group-filter controls
- apply group-based filtering with role filters reset when groups are used

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688da993f1108320b8aa7d7b0bb07447