### PR TITLE
feat: add reactive store with undo redo

### DIFF
--- a/canvas-store/README.md
+++ b/canvas-store/README.md
@@ -1,0 +1,23 @@
+# Canvas Store Scaffold
+
+A minimal reactive store with undo/redo support for canvas-like applications.
+
+## Features
+- Subscribe to state changes.
+- `setState` merges partial updates and records history for undo/redo.
+- `replaceState` swaps state entirely.
+- `undo`/`redo` operations with history stacks.
+
+## Usage
+```
+const { Store } = require('./store');
+const store = new Store({ count: 0 });
+store.subscribe((state) => console.log(state));
+store.setState({ count: 1 });
+store.undo();
+```
+
+Run tests with:
+```
+node store.test.js
+```

--- a/canvas-store/store.js
+++ b/canvas-store/store.js
@@ -1,0 +1,57 @@
+class Store {
+  constructor(initialState = {}) {
+    this.state = structuredClone(initialState);
+    this.listeners = new Set();
+    this.history = [];
+    this.future = [];
+  }
+
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  notify() {
+    for (const listener of this.listeners) {
+      listener(this.state);
+    }
+  }
+
+  setState(partial) {
+    // Save snapshot for undo
+    this.history.push(structuredClone(this.state));
+    // Clear redo stack
+    this.future.length = 0;
+    Object.assign(this.state, partial);
+    this.notify();
+  }
+
+  replaceState(nextState) {
+    this.history.push(structuredClone(this.state));
+    this.future.length = 0;
+    this.state = structuredClone(nextState);
+    this.notify();
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  undo() {
+    if (this.history.length === 0) return;
+    const prev = this.history.pop();
+    this.future.push(structuredClone(this.state));
+    this.state = prev;
+    this.notify();
+  }
+
+  redo() {
+    if (this.future.length === 0) return;
+    const next = this.future.pop();
+    this.history.push(structuredClone(this.state));
+    this.state = next;
+    this.notify();
+  }
+}
+
+module.exports = { Store };

--- a/canvas-store/store.test.js
+++ b/canvas-store/store.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { Store } = require('./store');
+
+// Simple tests for Store functionality
+(function testStore() {
+  const store = new Store({ count: 0 });
+  let observed = null;
+  store.subscribe((state) => {
+    observed = state.count;
+  });
+
+  store.setState({ count: 1 });
+  assert.strictEqual(store.getState().count, 1);
+  assert.strictEqual(observed, 1);
+
+  store.setState({ count: 2 });
+  store.undo();
+  assert.strictEqual(store.getState().count, 1);
+
+  store.redo();
+  assert.strictEqual(store.getState().count, 2);
+
+  store.replaceState({ count: 5 });
+  assert.strictEqual(store.getState().count, 5);
+
+  console.log('All tests passed');
+})();


### PR DESCRIPTION
## Summary
- scaffold reactive store with history-based undo/redo
- document store usage and basic tests

## Testing
- `node canvas-store/store.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688dac125c608320bf237dacc3106d81