### PR TITLE
Prevent trackpad zoom from affecting entire app

### DIFF
--- a/node interaction canvas
+++ b/node interaction canvas
@@ -30,7 +30,7 @@
             width: 100%;
             height: 100%;
             background: #0d0d0d;
-            background-image: 
+            background-image:
                 radial-gradient(circle at 1px 1px, #1a1a1a 1px, transparent 1px);
             background-size: 40px 40px;
             position: absolute;
@@ -38,6 +38,7 @@
             transform-origin: 0 0;
             transition: cursor 0.15s ease;
             will-change: transform;
+            touch-action: none;
         }
 
         #canvas.grabbing {
@@ -1391,7 +1392,10 @@
         
         // Canvas controls
         function setupEventListeners() {
-            state.canvas.addEventListener('wheel', handleWheel, { passive: false });
+            window.addEventListener('wheel', handleWheel, { passive: false });
+            window.addEventListener('gesturestart', e => e.preventDefault(), { passive: false });
+            window.addEventListener('gesturechange', e => e.preventDefault(), { passive: false });
+            window.addEventListener('gestureend', e => e.preventDefault(), { passive: false });
             state.canvas.addEventListener('mousedown', handleCanvasMouseDown);
             state.canvas.addEventListener('dblclick', handleCanvasDoubleClick);
             document.addEventListener('keydown', handleKeyDown);
@@ -1402,7 +1406,7 @@
                     updateMinimap();
                 });
             });
-            
+
             // Connection type selector
             const selector = document.getElementById('connectionTypeSelector');
             selector.querySelectorAll('.connection-type-option').forEach(option => {
@@ -1426,6 +1430,12 @@
         }
         
         function handleWheel(e) {
+            if (!state.canvas.contains(e.target)) {
+                if (e.ctrlKey) {
+                    e.preventDefault();
+                }
+                return;
+            }
             if (e.ctrlKey) {
                 e.preventDefault();
                 const delta = e.deltaY > 0 ? 0.9 : 1.1;


### PR DESCRIPTION
## Summary
- Disable default pinch gestures on the canvas
- Route wheel/gesture events through window and prevent browser zoom
- Ignore wheel events originating outside the canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dad46cd7483209d6d504c5186b53f