### PR TITLE
Add role groups and flow sets

### DIFF
--- a/node interaction canvas
+++ b/node interaction canvas
@@ -1107,7 +1107,7 @@
         <div class="controls">
             <div class="control-group">
                 <button onclick="App.createNewFlow()" title="Create new flow">New Flow</button>
-                <button onclick="App.groupSelected()" title="Group selected flows">Group</button>
+                <button onclick="App.createSet()" title="Group selected flows into a set">Create Set</button>
                 <button onclick="App.exportAsText()" title="Export as text">Export</button>
             </div>
 
@@ -1244,6 +1244,7 @@
             flows: [],
             connections: [],
             groups: [],
+            sets: [],
             selectedItems: new Set(),
             draggedItem: null,
             connectingPort: null,
@@ -1261,6 +1262,7 @@
             flowIdCounter: 0,
             nodeIdCounter: 0,
             groupIdCounter: 0,
+            setIdCounter: 0,
             dragThreshold: 5,
             animationFrame: null,
             updateQueue: new Set(),
@@ -1272,6 +1274,8 @@
             // Group filtering
             activeGroups: new Set(['all']),
             availableGroups: new Set(),
+            // Placeholder for future set filtering
+            activeSets: new Set(['all']),
         };
         
         // Sample data
@@ -2432,6 +2436,19 @@
             updateAvailableGroups();
         }
 
+        function createSetFromSelection(name) {
+            const selectedFlows = Array.from(state.selectedItems).filter(item => item.element && item.element.classList.contains('flow'));
+            if (!selectedFlows.length) return;
+            const set = {
+                id: state.setIdCounter++,
+                name: name || `Set ${state.setIdCounter}`,
+                flows: selectedFlows
+            };
+            state.sets.push(set);
+            state.selectedItems.clear();
+            selectedFlows.forEach(f => f.element.classList.remove('selected'));
+        }
+
         function serializeFlow(flow) {
             return {
                 x: flow.x,
@@ -3017,7 +3034,13 @@
 
             updateAvailableGroups();
         };
-        
+
+        App.createSet = function() {
+            if (state.selectedItems.size === 0) return;
+            const name = prompt('Set name?');
+            createSetFromSelection(name);
+        };
+
         App.exportAsText = function() {
             let text = 'Flow Process Map\n================\n\n';
             

--- a/org design
+++ b/org design
@@ -1497,6 +1497,7 @@ Please create this for my organization with:
                 organizationName: '',
                 people: [],
                 roles: [],
+                roleGroups: [],
                 flows: [],
                 currentTheme: 'light',
                 autoSave: true,
@@ -1898,6 +1899,12 @@ Please create this for my organization with:
                         <h1 class="profile-title">${role.name}</h1>
                         <p class="profile-subtitle">${role.code}</p>
                         <div class="profile-meta">
+                            ${role.group ? `
+                            <div class="profile-meta-item">
+                                <span class="profile-meta-label">Group</span>
+                                <span class="profile-meta-value">${role.group}</span>
+                            </div>
+                            ` : ''}
                             <div class="profile-meta-item">
                                 <span class="profile-meta-label">People in Role</span>
                                 <span class="profile-meta-value">${people.length}</span>
@@ -2410,7 +2417,7 @@ Please create this for my organization with:
                                     <h3 class="card-title clickable-name">
                                         ${role.name}
                                     </h3>
-                                    <p class="card-subtitle">${role.code}</p>
+                                    <p class="card-subtitle">${role.code}${role.group ? ' • ' + role.group : ''}</p>
                                 </div>
                                 <div style="display: flex; align-items: center; gap: calc(var(--spacing) * 1);">
                                     <span class="badge badge-blue">${peopleCount} people</span>
@@ -2567,6 +2574,10 @@ Please create this for my organization with:
                                 <input type="text" class="form-input" name="code" required placeholder="e.g., MGR, SALES">
                             </div>
                             <div class="form-group">
+                                <label class="form-label">Group</label>
+                                <input type="text" class="form-input" name="group" placeholder="Enter group name">
+                            </div>
+                            <div class="form-group">
                                 <label class="form-label">Responsibilities (one per line)</label>
                                 <textarea class="form-textarea" name="responsibilities" required></textarea>
                             </div>
@@ -2666,10 +2677,14 @@ Please create this for my organization with:
                     id: Date.now(),
                     name: form.name.value,
                     code: form.code.value.toUpperCase(),
+                    group: form.group.value.trim(),
                     responsibilities: form.responsibilities.value.split('\n').filter(r => r.trim()),
                     ownership: form.ownership.value.split('\n').filter(o => o.trim()),
                     isTemplate: false
                 };
+                if (newRole.group && !this.data.roleGroups.includes(newRole.group)) {
+                    this.data.roleGroups.push(newRole.group);
+                }
                 this.data.roles.push(newRole);
                 this.data.hasChanges = true;
                 if (this.data.autoSave !== false) this.saveData();
@@ -3565,6 +3580,10 @@ Please create this for my organization with:
                                 <input type="text" class="form-input" name="code" value="${role.code}" required>
                             </div>
                             <div class="form-group">
+                                <label class="form-label">Group</label>
+                                <input type="text" class="form-input" name="group" value="${role.group || ''}">
+                            </div>
+                            <div class="form-group">
                                 <label class="form-label">Responsibilities (one per line)</label>
                                 <textarea class="form-textarea" name="responsibilities" required>${role.responsibilities.join('\n')}</textarea>
                             </div>
@@ -3595,10 +3614,14 @@ Please create this for my organization with:
                     ...this.data.roles[roleIndex],
                     name: newName,
                     code: form.code.value.toUpperCase(),
+                    group: form.group.value.trim(),
                     responsibilities: form.responsibilities.value.split('\n').filter(r => r.trim()),
                     ownership: form.ownership.value.split('\n').filter(o => o.trim()),
                     isTemplate: false  // Once edited, no longer template data
                 };
+                if (form.group.value.trim() && !this.data.roleGroups.includes(form.group.value.trim())) {
+                    this.data.roleGroups.push(form.group.value.trim());
+                }
                 
                 // Update flow counterpart names if role name changed
                 if (oldName !== newName) {


### PR DESCRIPTION
## Summary
- enable grouping roles into named buckets and show group on role cards
- allow creating sets from selected flows on the canvas

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e330f704083208c59f90d02520568