### PR TITLE
feat: improve canvas navigation and edge layering

### DIFF
--- a/node-edge/Canvas.vue
+++ b/node-edge/Canvas.vue
@@ -1,0 +1,92 @@
+<template>
+  <div
+    ref="wrapper"
+    class="canvas"
+    @mousedown="onMouseDown"
+    @wheel.prevent="onWheel"
+  >
+    <div class="inner" :style="transform" ref="inner">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, reactive, computed, onMounted, onBeforeUnmount } from 'vue';
+
+export default defineComponent({
+  name: 'Canvas',
+  setup() {
+    const state = reactive({
+      x: 0,
+      y: 0,
+      scale: 1,
+      panning: false,
+      lastX: 0,
+      lastY: 0,
+    });
+    const wrapper = ref<HTMLDivElement | null>(null);
+
+    const transform = computed(() => `transform: translate(${state.x}px, ${state.y}px) scale(${state.scale});`);
+
+    function onWheel(e: WheelEvent) {
+      const delta = e.deltaY > 0 ? -0.1 : 0.1;
+      state.scale = Math.min(Math.max(state.scale + delta, 0.2), 2);
+    }
+
+    function onMouseDown(e: MouseEvent) {
+      // middle click or left-click on empty space starts panning
+      if (e.button === 1 || (e.button === 0 && e.target === wrapper.value)) {
+        state.panning = true;
+        state.lastX = e.clientX;
+        state.lastY = e.clientY;
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('mouseup', onMouseUp);
+      }
+    }
+
+    function onMouseMove(e: MouseEvent) {
+      if (!state.panning) return;
+      const dx = e.clientX - state.lastX;
+      const dy = e.clientY - state.lastY;
+      state.x += dx;
+      state.y += dy;
+      state.lastX = e.clientX;
+      state.lastY = e.clientY;
+    }
+
+    function onMouseUp() {
+      state.panning = false;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    }
+
+    onMounted(() => {
+      // ensure we cleanup if component is destroyed during pan
+      onBeforeUnmount(() => onMouseUp());
+    });
+
+    return { wrapper, transform, onMouseDown, onWheel };
+  },
+});
+</script>
+
+<style scoped>
+.canvas {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  cursor: grab;
+}
+.canvas:active {
+  cursor: grabbing;
+}
+.inner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: 0 0;
+}
+</style>
+

--- a/node-edge/CanvasEdge.vue
+++ b/node-edge/CanvasEdge.vue
@@ -1,7 +1,13 @@
 <!-- Adapted from n8n's editor-ui under the Sustainable Use License. -->
 <template>
   <svg class="edge" :width="width" :height="height">
-    <path :d="path" :stroke="color" fill="none" stroke-width="2" />
+    <path
+      :d="path"
+      :stroke="color"
+      fill="none"
+      stroke-width="2"
+      vector-effect="non-scaling-stroke"
+    />
   </svg>
 </template>
 
@@ -29,5 +35,8 @@ export default defineComponent({
 <style scoped>
 .edge {
   overflow: visible;
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
 }
 </style>

--- a/node-edge/README.md
+++ b/node-edge/README.md
@@ -1,5 +1,10 @@
 # Node Edge Components
 
-This directory contains a minimal extraction of the edge-drawing logic from the n8n editor UI.
+This directory contains a minimal extraction of the canvas components used for building node graphs, inspired by the n8n editor UI.
+
+## Components
+
+- `Canvas.vue` – provides simple pan/zoom navigation similar to n8n's editor. Drag the background or use the mouse wheel to move around the canvas.
+- `CanvasEdge.vue` – renders bezier edges behind nodes with a non-scaling stroke to keep them flat.
 
 Source code is adapted from the n8n project and is subject to the [Sustainable Use License](https://github.com/n8n-io/n8n/blob/master/packages/frontend/editor-ui/LICENSE.md).


### PR DESCRIPTION
## Summary
- add Canvas component with pan & zoom interaction
- render edges behind nodes with non-scaling stroke
- document new canvas utilities

## Testing
- `node canvas-store/store.test.js`


------
https://chatgpt.com/codex/tasks/task_b_688e8bfbfc148332a1a2c639a17c77ca