### PR TITLE
Add archive UI with flow and role pages

### DIFF
--- a/archive-ui/archive.js
+++ b/archive-ui/archive.js
@@ -1,0 +1,9 @@
+async function loadArchive() {
+  const res = await fetch('../team-operations-archive.json');
+  return res.json();
+}
+
+function getQueryParam(name) {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(name);
+}

--- a/archive-ui/flow.html
+++ b/archive-ui/flow.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flow</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <a href="flows.html" class="back-link">← Back</a>
+    <div class="header">
+      <div class="breadcrumb">Team Operations // Archive</div>
+      <div class="header-tabs">
+        <a href="overview.html" class="tab">Overview</a>
+        <a href="people.html" class="tab">People</a>
+        <a href="roles.html" class="tab">Roles</a>
+        <a href="groups.html" class="tab">Groups</a>
+        <a href="flows.html" class="tab active">Flows</a>
+      </div>
+      <div class="header-actions">
+        <button class="btn btn-secondary">⚠️ Changes since download just now</button>
+        <button class="btn btn-primary">💾 Save</button>
+        <button class="btn btn-secondary">⚙️ Settings</button>
+      </div>
+    </div>
+
+    <div class="main-content">
+      <div class="relationship-visual">
+        <h2 class="relationship-statement" id="rel-statement"></h2>
+        <div class="relationship-diagram">
+          <a id="role-a" class="role-box">
+            <div class="role-name" id="role-a-name"></div>
+            <div class="role-code" id="role-a-code"></div>
+            <div class="role-count" id="role-a-count"></div>
+          </a>
+          <div class="relationship-arrow">
+            <div class="arrow-line">
+              <div class="arrow-head"></div>
+            </div>
+            <div class="relationship-label" id="rel-label"></div>
+          </div>
+          <a id="role-b" class="role-box">
+            <div class="role-name" id="role-b-name"></div>
+            <div class="role-code" id="role-b-code"></div>
+            <div class="role-count" id="role-b-count"></div>
+          </a>
+        </div>
+        <div class="relationship-meta">
+          <div class="meta-item">
+            <div class="meta-icon">📅</div>
+            <span id="meta-updated"></span>
+          </div>
+          <div class="meta-item">
+            <div class="meta-icon">🔄</div>
+            <span>Frequency: daily</span>
+          </div>
+          <div class="meta-item">
+            <div class="meta-icon">📊</div>
+            <span>Strength: 80%</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="details-grid">
+        <div class="detail-section">
+          <h3 class="detail-title"><span>🎯</span>Relationship Type</h3>
+          <p style="margin:0; line-height:1.6;">
+            <span class="highlight" id="rel-type-highlight">Designates</span> - Has authority over
+          </p>
+          <div class="category-tag"><span>🏷️</span><span>Category: identity</span></div>
+        </div>
+        <div class="detail-section">
+          <h3 class="detail-title"><span>💪</span>Flow Details</h3>
+          <p style="margin:0 0 16px 0; font-size:14px; color:#666;">
+            Flow type: roles • Type: SAMPLE DATA
+          </p>
+          <div class="strength-indicator">
+            <div class="strength-bar">
+              <div class="strength-fill"></div>
+            </div>
+            <div class="strength-label">
+              <span>0%</span>
+              <span style="font-weight:600; color:#4caf50;">80%</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="people-section">
+        <h3 class="people-header">People Affected</h3>
+        <p class="people-narrative">People in the initiating role who can perform this action:</p>
+        <div id="people-list"></div>
+      </div>
+
+      <div class="action-footer">
+        <button class="btn btn-secondary">Edit Flow</button>
+        <button class="btn btn-secondary" style="color:#d32f2f;">Delete Flow</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="archive.js"></script>
+  <script>
+  (async function(){
+    const data = await loadArchive();
+    const id = parseInt(getQueryParam('id'),10);
+    const flow = data.flows.find(f=>f.id===id);
+    if(!flow){
+      document.getElementById('rel-statement').textContent='Flow not found';
+      return;
+    }
+    const roleA = data.roles.find(r=>r.id===flow.roleId);
+    const roleB = data.roles.find(r=>r.id===flow.counterpartRoleIds[0]);
+    document.getElementById('rel-statement').innerHTML = `${roleA.name} <span class="highlight">has authority over</span> ${roleB.name}`;
+    document.getElementById('rel-label').textContent = `${flow.action} ${flow.connection} for`;
+    document.getElementById('role-a').href = `role.html?id=${roleA.id}`;
+    document.getElementById('role-a-name').textContent = roleA.name;
+    document.getElementById('role-a-code').textContent = roleA.code;
+    document.getElementById('role-a-count').textContent = data.people.filter(p=>p.roleId===roleA.id).length + ' people';
+    document.getElementById('role-b').href = `role.html?id=${roleB.id}`;
+    document.getElementById('role-b-name').textContent = roleB.name;
+    document.getElementById('role-b-code').textContent = roleB.code;
+    document.getElementById('role-b-count').textContent = data.people.filter(p=>p.roleId===roleB.id).length + ' people';
+    document.getElementById('meta-updated').textContent = `Last updated: ${flow.updated}`;
+    const peopleList = document.getElementById('people-list');
+    const people = data.people.filter(p=>p.roleId===roleA.id);
+    if(people.length===0){
+      peopleList.innerHTML = '<p class="people-narrative">No people recorded.</p>';
+    } else {
+      people.forEach(p=>{
+        const item=document.createElement('a');
+        item.href=`person.html?id=${p.id}`;
+        item.className='person-item';
+        item.innerHTML=`<div class="person-avatar">${p.name.match(/\b\w/g).join('').toUpperCase()}</div><div class="person-details"><div class="person-name">${p.name}</div><div class="person-dept">${p.department||''}</div></div>`;
+        peopleList.appendChild(item);
+      });
+    }
+  })();
+  </script>
+</body>
+</html>

--- a/archive-ui/flows.html
+++ b/archive-ui/flows.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flows</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="breadcrumb">Team Operations // Archive</div>
+      <div class="header-tabs">
+        <a href="overview.html" class="tab">Overview</a>
+        <a href="people.html" class="tab">People</a>
+        <a href="roles.html" class="tab">Roles</a>
+        <a href="groups.html" class="tab">Groups</a>
+        <a href="flows.html" class="tab active">Flows</a>
+      </div>
+    </div>
+    <div class="main-content">
+      <h2>Flows</h2>
+      <div id="flow-list"></div>
+    </div>
+  </div>
+  <script src="archive.js"></script>
+  <script>
+  (async function(){
+    const data = await loadArchive();
+    const list = document.getElementById('flow-list');
+    if(data.flows.length===0){
+      list.innerHTML = '<p class="people-narrative">No flows recorded.</p>';
+      return;
+    }
+    data.flows.forEach(f=>{
+      const role = data.roles.find(r=>r.id===f.roleId);
+      const counterpart = data.roles.find(r=>r.id===f.counterpartRoleIds[0]);
+      const a=document.createElement('a');
+      a.href=`flow.html?id=${f.id}`;
+      a.className='person-item';
+      a.innerHTML=`<div class="person-details"><div class="person-name">${role.name} ↦ ${counterpart.name}</div><div class="person-dept">${f.action} ${f.connection}</div></div>`;
+      list.appendChild(a);
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/archive-ui/group.html
+++ b/archive-ui/group.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Group</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <a href="groups.html" class="back-link">← Back</a>
+    <div class="header">
+      <div class="breadcrumb">Team Operations // Archive</div>
+      <div class="header-tabs">
+        <a href="overview.html" class="tab">Overview</a>
+        <a href="people.html" class="tab">People</a>
+        <a href="roles.html" class="tab">Roles</a>
+        <a href="groups.html" class="tab active">Groups</a>
+        <a href="flows.html" class="tab">Flows</a>
+      </div>
+    </div>
+    <div class="main-content">
+      <h2 id="group-name">Group</h2>
+    </div>
+  </div>
+  <script src="archive.js"></script>
+  <script>
+  (async function(){
+    const data = await loadArchive();
+    const id = parseInt(getQueryParam('id'),10);
+    const group = data.groups.find(g=>g.id===id);
+    if(!group){
+      document.getElementById('group-name').textContent='Group not found';
+      return;
+    }
+    document.getElementById('group-name').textContent = group.name;
+  })();
+  </script>
+</body>
+</html>

--- a/archive-ui/groups.html
+++ b/archive-ui/groups.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Groups</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="breadcrumb">Team Operations // Archive</div>
+      <div class="header-tabs">
+        <a href="overview.html" class="tab">Overview</a>
+        <a href="people.html" class="tab">People</a>
+        <a href="roles.html" class="tab">Roles</a>
+        <a href="groups.html" class="tab active">Groups</a>
+        <a href="flows.html" class="tab">Flows</a>
+      </div>
+    </div>
+    <div class="main-content">
+      <h2>Groups</h2>
+      <div id="group-list" class="people-narrative"></div>
+    </div>
+  </div>
+  <script src="archive.js"></script>
+  <script>
+  (async function(){
+    const data = await loadArchive();
+    const list = document.getElementById('group-list');
+    if(data.groups.length===0){
+      list.textContent = 'No groups recorded.';
+    }
+    data.groups.forEach(g=>{
+      const a=document.createElement('a');
+      a.href=`group.html?id=${g.id}`;
+      a.className='person-item';
+      a.innerHTML=`<div class="person-details"><div class="person-name">${g.name}</div></div>`;
+      list.appendChild(a);
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/archive-ui/overview.html
+++ b/archive-ui/overview.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Team Operations Archive</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="breadcrumb">Team Operations // Archive</div>
+      <div class="header-tabs">
+        <a href="overview.html" class="tab active">Overview</a>
+        <a href="people.html" class="tab">People</a>
+        <a href="roles.html" class="tab">Roles</a>
+        <a href="groups.html" class="tab">Groups</a>
+        <a href="flows.html" class="tab">Flows</a>
+      </div>
+    </div>
+    <div class="main-content">
+      <h2>Overview</h2>
+      <div id="stats"></div>
+    </div>
+  </div>
+  <script src="archive.js"></script>
+  <script>
+  (async function(){
+    const data = await loadArchive();
+    const stats = document.getElementById('stats');
+    stats.innerHTML = `Roles: ${data.roles.length} &bull; Flows: ${data.flows.length} &bull; People: ${data.people.length} &bull; Groups: ${data.groups.length}`;
+  })();
+  </script>
+</body>
+</html>

--- a/archive-ui/people.html
+++ b/archive-ui/people.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>People</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="breadcrumb">Team Operations // Archive</div>
+      <div class="header-tabs">
+        <a href="overview.html" class="tab">Overview</a>
+        <a href="people.html" class="tab active">People</a>
+        <a href="roles.html" class="tab">Roles</a>
+        <a href="groups.html" class="tab">Groups</a>
+        <a href="flows.html" class="tab">Flows</a>
+      </div>
+    </div>
+    <div class="main-content">
+      <h2>People</h2>
+      <div id="people-list" class="people-narrative"></div>
+    </div>
+  </div>
+  <script src="archive.js"></script>
+  <script>
+  (async function(){
+    const data = await loadArchive();
+    const list = document.getElementById('people-list');
+    if(data.people.length===0){
+      list.textContent = 'No people recorded.';
+    }
+    data.people.forEach(p=>{
+      const a=document.createElement('a');
+      a.href=`person.html?id=${p.id}`;
+      a.className='person-item';
+      a.innerHTML=`<div class="person-avatar">${p.name.match(/\b\w/g).join('').toUpperCase()}</div><div class="person-details"><div class="person-name">${p.name}</div><div class="person-dept">${p.department||''}</div></div>`;
+      list.appendChild(a);
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/archive-ui/person.html
+++ b/archive-ui/person.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Person</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <a href="people.html" class="back-link">← Back</a>
+    <div class="header">
+      <div class="breadcrumb">Team Operations // Archive</div>
+      <div class="header-tabs">
+        <a href="overview.html" class="tab">Overview</a>
+        <a href="people.html" class="tab active">People</a>
+        <a href="roles.html" class="tab">Roles</a>
+        <a href="groups.html" class="tab">Groups</a>
+        <a href="flows.html" class="tab">Flows</a>
+      </div>
+    </div>
+    <div class="main-content">
+      <h2 id="person-name">Person</h2>
+      <div id="person-dept" class="people-narrative"></div>
+    </div>
+  </div>
+  <script src="archive.js"></script>
+  <script>
+  (async function(){
+    const data = await loadArchive();
+    const id = parseInt(getQueryParam('id'),10);
+    const person = data.people.find(p=>p.id===id);
+    if(!person){
+      document.getElementById('person-name').textContent='Person not found';
+      return;
+    }
+    document.getElementById('person-name').textContent = person.name;
+    document.getElementById('person-dept').textContent = person.department || '';
+  })();
+  </script>
+</body>
+</html>

--- a/archive-ui/role.html
+++ b/archive-ui/role.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Role</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <a href="roles.html" class="back-link">← Back</a>
+    <div class="header">
+      <div class="breadcrumb">Team Operations // Archive</div>
+      <div class="header-tabs">
+        <a href="overview.html" class="tab">Overview</a>
+        <a href="people.html" class="tab">People</a>
+        <a href="roles.html" class="tab active">Roles</a>
+        <a href="groups.html" class="tab">Groups</a>
+        <a href="flows.html" class="tab">Flows</a>
+      </div>
+    </div>
+    <div class="main-content">
+      <h2 id="role-name">Role</h2>
+      <div id="role-code" class="people-narrative"></div>
+      <h3 class="people-header">Flows</h3>
+      <div id="role-flows"></div>
+    </div>
+  </div>
+  <script src="archive.js"></script>
+  <script>
+  (async function(){
+    const data = await loadArchive();
+    const id = parseInt(getQueryParam('id'),10);
+    const role = data.roles.find(r=>r.id===id);
+    if(!role){
+      document.getElementById('role-name').textContent = 'Role not found';
+      return;
+    }
+    document.getElementById('role-name').textContent = role.name;
+    document.getElementById('role-code').textContent = `Code: ${role.code}`;
+    const flows = data.flows.filter(f=>f.roleId===id || f.counterpartRoleIds.includes(id));
+    const container = document.getElementById('role-flows');
+    if(flows.length===0){
+      container.innerHTML = '<p class="people-narrative">No flows recorded.</p>';
+    }
+    flows.forEach(f=>{
+      const otherId = f.roleId===id ? f.counterpartRoleIds[0] : f.roleId;
+      const otherRole = data.roles.find(r=>r.id===otherId);
+      const a = document.createElement('a');
+      a.href = `flow.html?id=${f.id}`;
+      a.className = 'person-item';
+      a.innerHTML = `<div class="person-details"><div class="person-name">${role.name} ↔ ${otherRole.name}</div><div class="person-dept">${f.action} ${f.connection}</div></div>`;
+      container.appendChild(a);
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/archive-ui/roles.html
+++ b/archive-ui/roles.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Roles</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="breadcrumb">Team Operations // Archive</div>
+      <div class="header-tabs">
+        <a href="overview.html" class="tab">Overview</a>
+        <a href="people.html" class="tab">People</a>
+        <a href="roles.html" class="tab active">Roles</a>
+        <a href="groups.html" class="tab">Groups</a>
+        <a href="flows.html" class="tab">Flows</a>
+      </div>
+    </div>
+    <div class="main-content">
+      <h2>Roles</h2>
+      <div id="role-list"></div>
+    </div>
+  </div>
+  <script src="archive.js"></script>
+  <script>
+  (async function(){
+    const data = await loadArchive();
+    const list = document.getElementById('role-list');
+    data.roles.forEach(r => {
+      const a = document.createElement('a');
+      a.href = `role.html?id=${r.id}`;
+      a.className = 'person-item';
+      a.innerHTML = `<div class="person-details"><div class="person-name">${r.name}</div><div class="person-dept">${r.code}</div></div>`;
+      list.appendChild(a);
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/archive-ui/style.css
+++ b/archive-ui/style.css
@@ -1,0 +1,352 @@
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #f8f9fa;
+    margin: 0;
+    padding: 20px;
+    color: #1a1a1a;
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.header {
+    background: white;
+    padding: 20px 28px;
+    border-radius: 12px 12px 0 0;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.breadcrumb {
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 16px;
+}
+
+.header-tabs {
+    display: flex;
+    gap: 24px;
+    margin-bottom: 20px;
+}
+
+.tab {
+    font-size: 14px;
+    color: #666;
+    text-decoration: none;
+    padding-bottom: 4px;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s;
+}
+
+.tab.active {
+    color: #1976d2;
+    border-bottom-color: #1976d2;
+    font-weight: 500;
+}
+
+.header-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    margin-top: -40px;
+}
+
+.btn {
+    padding: 8px 20px;
+    border-radius: 6px;
+    border: none;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-secondary {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.btn-primary {
+    background: #1976d2;
+    color: white;
+}
+
+.btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.main-content {
+    background: white;
+    border-radius: 0 0 12px 12px;
+    padding: 40px;
+}
+
+.relationship-visual {
+    background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+    border-radius: 16px;
+    padding: 40px;
+    margin-bottom: 40px;
+    text-align: center;
+}
+
+.relationship-diagram {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 40px;
+    margin: 20px 0 32px;
+}
+
+.role-box {
+    background: white;
+    padding: 24px 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transition: all 0.3s;
+    cursor: pointer;
+    text-decoration: none;
+    color: inherit;
+}
+
+.role-box:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+}
+
+.role-name {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 4px;
+}
+
+.role-code {
+    font-size: 14px;
+    color: #666;
+}
+
+.role-count {
+    font-size: 12px;
+    color: #1976d2;
+    margin-top: 8px;
+}
+
+.relationship-arrow {
+    flex: 0 0 120px;
+    position: relative;
+}
+
+.arrow-line {
+    height: 4px;
+    background: #1976d2;
+    position: relative;
+    border-radius: 2px;
+}
+
+.arrow-head {
+    position: absolute;
+    right: -8px;
+    top: -8px;
+    width: 0;
+    height: 0;
+    border-left: 12px solid #1976d2;
+    border-top: 10px solid transparent;
+    border-bottom: 10px solid transparent;
+}
+
+.relationship-label {
+    position: absolute;
+    top: -28px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 14px;
+    font-weight: 600;
+    color: #1976d2;
+    white-space: nowrap;
+}
+
+.relationship-statement {
+    font-size: 24px;
+    color: #2c3e50;
+    margin-bottom: 16px;
+}
+
+.relationship-meta {
+    display: flex;
+    justify-content: center;
+    gap: 32px;
+    font-size: 14px;
+    color: #666;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.meta-icon {
+    width: 20px;
+    height: 20px;
+    background: #e8f4f8;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+}
+
+.details-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+    margin-bottom: 40px;
+}
+
+.detail-section {
+    background: #f8f9fa;
+    padding: 24px;
+    border-radius: 12px;
+}
+
+.detail-title {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.strength-indicator {
+    margin-top: 16px;
+}
+
+.strength-bar {
+    height: 8px;
+    background: #e0e0e0;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.strength-fill {
+    height: 100%;
+    background: #4caf50;
+    width: 80%;
+    transition: width 0.5s ease;
+}
+
+.strength-label {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 8px;
+    font-size: 14px;
+}
+
+.category-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: #e3f2fd;
+    color: #1976d2;
+    padding: 6px 16px;
+    border-radius: 20px;
+    font-size: 14px;
+    margin-top: 12px;
+}
+
+.people-section {
+    background: #fafafa;
+    padding: 32px;
+    border-radius: 12px;
+    margin-top: 32px;
+}
+
+.people-header {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 20px;
+}
+
+.people-narrative {
+    font-size: 16px;
+    color: #666;
+    margin-bottom: 24px;
+    line-height: 1.6;
+}
+
+.person-item {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 16px;
+    background: white;
+    border-radius: 8px;
+    margin-bottom: 12px;
+    transition: all 0.2s;
+}
+
+.person-item:hover {
+    transform: translateX(4px);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.person-avatar {
+    width: 40px;
+    height: 40px;
+    background: #1976d2;
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+}
+
+.person-details {
+    flex: 1;
+}
+
+.person-name {
+    font-weight: 600;
+    margin-bottom: 2px;
+}
+
+.person-dept {
+    font-size: 14px;
+    color: #666;
+}
+
+.action-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 40px;
+    padding-top: 32px;
+    border-top: 1px solid #e0e0e0;
+}
+
+.highlight {
+    background: #fff3cd;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-weight: 500;
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: #666;
+    text-decoration: none;
+    font-size: 14px;
+    margin-bottom: 16px;
+    transition: all 0.2s;
+}
+
+.back-link:hover {
+    color: #1976d2;
+    gap: 12px;
+}


### PR DESCRIPTION
## Summary
- Implement static archive UI with overview, people, roles, groups, and flows listing pages.
- Add flow detail page showing relationship diagram and metadata with links to role profiles.
- Create reusable archive loader script and shared styling.

## Testing
- `node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('team-operations-archive.json','utf8'));console.log('roles',data.roles.length,'flows',data.flows.length);"`


------
https://chatgpt.com/codex/tasks/task_b_688ef81ca12883329b4ef67f7c81dcf8