### PR TITLE
Fix flow creation when structuredClone unavailable

### DIFF
--- a/canvas-store/flowMapper.js
+++ b/canvas-store/flowMapper.js
@@ -1,12 +1,12 @@
-const { Store } = require('./store');
+const { Store, clone } = require('./store');
 
 class FlowMapper {
   constructor(initialFlows = {}) {
-    this.store = new Store({ flows: structuredClone(initialFlows) });
+    this.store = new Store({ flows: clone(initialFlows) });
   }
 
   addFlow(id, label = '') {
-    const flows = structuredClone(this.store.getState().flows);
+    const flows = clone(this.store.getState().flows);
     if (flows[id]) throw new Error(`Flow ${id} already exists`);
     flows[id] = {
       id,
@@ -22,7 +22,7 @@ class FlowMapper {
   }
 
   setRole(flowId, role, value) {
-    const flows = structuredClone(this.store.getState().flows);
+    const flows = clone(this.store.getState().flows);
     if (!flows[flowId]) throw new Error(`Flow ${flowId} missing`);
     if (!['INS', 'P', 'REC'].includes(role)) throw new Error(`Invalid role ${role}`);
     flows[flowId].roles[role] = value;

--- a/canvas-store/flowMapper.test.js
+++ b/canvas-store/flowMapper.test.js
@@ -1,22 +1,43 @@
 const assert = require('assert');
-const { FlowMapper } = require('./flowMapper');
 
-const mapper = new FlowMapper();
+// Run tests with native structuredClone present
+(function () {
+  const { FlowMapper } = require('./flowMapper');
+  const mapper = new FlowMapper();
 
-// add two flows
-mapper.addFlow('flow-1', 'Example Flow 1');
-mapper.addFlow('flow-2', 'Example Flow 2');
+  // add two flows
+  mapper.addFlow('flow-1', 'Example Flow 1');
+  mapper.addFlow('flow-2', 'Example Flow 2');
 
-// embed flow-2 as pattern role inside flow-1
-mapper.setRole('flow-1', 'INS', { type: 'inline', value: 'Manager' });
-mapper.setRole('flow-1', 'P', { type: 'flow', reference: 'flow-2' });
-mapper.setRole('flow-1', 'REC', { type: 'inline', value: 'Report' });
+  // embed flow-2 as pattern role inside flow-1
+  mapper.setRole('flow-1', 'INS', { type: 'inline', value: 'Manager' });
+  mapper.setRole('flow-1', 'P', { type: 'flow', reference: 'flow-2' });
+  mapper.setRole('flow-1', 'REC', { type: 'inline', value: 'Report' });
 
-assert(mapper.isTriadComplete('flow-1'), 'flow-1 should have a complete triad');
+  assert(mapper.isTriadComplete('flow-1'), 'flow-1 should have a complete triad');
 
-// incomplete flow
-mapper.addFlow('flow-3');
-mapper.setRole('flow-3', 'INS', { type: 'inline', value: 'User' });
-assert.strictEqual(mapper.isTriadComplete('flow-3'), false, 'flow-3 should be incomplete');
+  // incomplete flow
+  mapper.addFlow('flow-3');
+  mapper.setRole('flow-3', 'INS', { type: 'inline', value: 'User' });
+  assert.strictEqual(
+    mapper.isTriadComplete('flow-3'),
+    false,
+    'flow-3 should be incomplete'
+  );
 
-console.log('flowMapper tests passed');
+  console.log('flowMapper tests passed');
+})();
+
+// Simulate environment without structuredClone
+(function () {
+  const original = global.structuredClone;
+  delete global.structuredClone;
+  delete require.cache[require.resolve('./store')];
+  delete require.cache[require.resolve('./flowMapper')];
+  const { FlowMapper } = require('./flowMapper');
+  const mapper = new FlowMapper();
+  mapper.addFlow('fallback');
+  assert(mapper.getFlow('fallback'), 'flow should be added without structuredClone');
+  console.log('flowMapper fallback test passed');
+  global.structuredClone = original; // restore
+})();

--- a/canvas-store/store.js
+++ b/canvas-store/store.js
@@ -1,6 +1,11 @@
+const clone = (obj) =>
+  typeof structuredClone === 'function'
+    ? structuredClone(obj)
+    : JSON.parse(JSON.stringify(obj));
+
 class Store {
   constructor(initialState = {}) {
-    this.state = structuredClone(initialState);
+    this.state = clone(initialState);
     this.listeners = new Set();
     this.history = [];
     this.future = [];
@@ -19,7 +24,7 @@ class Store {
 
   setState(partial) {
     // Save snapshot for undo
-    this.history.push(structuredClone(this.state));
+    this.history.push(clone(this.state));
     // Clear redo stack
     this.future.length = 0;
     Object.assign(this.state, partial);
@@ -27,9 +32,9 @@ class Store {
   }
 
   replaceState(nextState) {
-    this.history.push(structuredClone(this.state));
+    this.history.push(clone(this.state));
     this.future.length = 0;
-    this.state = structuredClone(nextState);
+    this.state = clone(nextState);
     this.notify();
   }
 
@@ -40,7 +45,7 @@ class Store {
   undo() {
     if (this.history.length === 0) return;
     const prev = this.history.pop();
-    this.future.push(structuredClone(this.state));
+    this.future.push(clone(this.state));
     this.state = prev;
     this.notify();
   }
@@ -48,10 +53,10 @@ class Store {
   redo() {
     if (this.future.length === 0) return;
     const next = this.future.pop();
-    this.history.push(structuredClone(this.state));
+    this.history.push(clone(this.state));
     this.state = next;
     this.notify();
   }
 }
 
-module.exports = { Store };
+module.exports = { Store, clone };

--- a/canvas-store/store.test.js
+++ b/canvas-store/store.test.js
@@ -1,8 +1,8 @@
 const assert = require('assert');
-const { Store } = require('./store');
 
 // Simple tests for Store functionality
 (function testStore() {
+  const { Store } = require('./store');
   const store = new Store({ count: 0 });
   let observed = null;
   store.subscribe((state) => {
@@ -24,4 +24,17 @@ const { Store } = require('./store');
   assert.strictEqual(store.getState().count, 5);
 
   console.log('All tests passed');
+})();
+
+// Verify behavior without structuredClone
+(function testFallback() {
+  const original = global.structuredClone;
+  delete global.structuredClone;
+  delete require.cache[require.resolve('./store')];
+  const { Store } = require('./store');
+  const store = new Store({ count: 1 });
+  store.setState({ count: 2 });
+  assert.strictEqual(store.getState().count, 2);
+  console.log('Fallback tests passed');
+  global.structuredClone = original; // restore
 })();


### PR DESCRIPTION
## Summary
- add `clone` helper in store to fall back to JSON cloning when `structuredClone` isn't available
- use `clone` in `FlowMapper`
- add tests covering environments without `structuredClone`

## Testing
- `node canvas-store/store.test.js`
- `node canvas-store/flowMapper.test.js`


------
https://chatgpt.com/codex/tasks/task_b_688efa1bcf4c8332aa675ffe603f3cb1