### PR TITLE
feat: link canvas to org design data

### DIFF
--- a/node-interaction-canvas.html
+++ b/node-interaction-canvas.html
@@ -1349,7 +1349,10 @@
             setupEventListeners();
             updateCanvasTransform();
 
-            fetch('team-operations-archive.json')
+            const params = new URLSearchParams(window.location.search);
+            const dataFile = params.get('json') || 'team-operations-archive.json';
+
+            fetch(dataFile)
                 .then(r => r.json())
                 .then(data => {
                     data.flows.forEach((flow, index) => {

--- a/org-design-tool
+++ b/org-design-tool
@@ -1796,6 +1796,7 @@
                         <button class="nav-tab" onclick="window.app.showView('groups')">Groups</button>
                         <button class="nav-tab" onclick="window.app.showView('flows')">Flows</button>
                         <button class="nav-tab" onclick="window.app.showView('ai-assist')">AI Assist</button>
+                        <button class="nav-tab" onclick="window.app.openCanvas()">Canvas</button>
                     </nav>
                 </div>
                 <div class="header-right">
@@ -4476,7 +4477,13 @@ Please create this for my organization with:
                 goBack() {
                     this.showView(this.previousView);
                 },
-                
+
+                openCanvas() {
+                    const file = this.data.originalFileName || 'team-operations-archive.json';
+                    const url = `node-interaction-canvas.html?json=${encodeURIComponent(file)}`;
+                    window.open(url, '_blank');
+                },
+
                 // Show AI Assist from welcome screen
                 showAIAssistFromWelcome() {
                     // Initialize with empty data


### PR DESCRIPTION
## Summary
- let canvas accept a JSON file via query string
- add a Canvas tab in org design tool that opens the canvas with the active data file

## Testing
- `node canvas-store/store.test.js`
- `node canvas-store/flowMapper.test.js`


------
https://chatgpt.com/codex/tasks/task_b_688efa43dc0883328ab09027ffbeeb9c