### PR TITLE
Integrate FlowMapper groups with canvas components

### DIFF
--- a/canvas-store/README.md
+++ b/canvas-store/README.md
@@ -24,7 +24,7 @@ node store.test.js
 
 ## Flow Mapper
 
-`flowMapper.js` builds on the store to model flows with triadic roles. Each role (INS, P, REC) can embed an inline value or reference another flow by id.
+`flowMapper.js` builds on the store to model flows with triadic roles and optional grouping. Each role (INS, P, REC) can embed an inline value or reference another flow by id. Groups are simple containers with x/y coordinates that hold a list of flow ids.
 
 ### Example
 ```js
@@ -36,6 +36,9 @@ mapper.setRole('f1', 'INS', { type: 'inline', value: 'Manager' });
 mapper.setRole('f1', 'P', { type: 'flow', reference: 'f2' });
 mapper.setRole('f1', 'REC', { type: 'inline', value: 'Report' });
 console.log(mapper.isTriadComplete('f1')); // true
+mapper.addGroup('team', 'Team A', 100, 100);
+mapper.addFlowToGroup('f1', 'team');
+console.log(mapper.getGroup('team'));
 ```
 
 Run tests:

--- a/canvas-store/flowMapper.js
+++ b/canvas-store/flowMapper.js
@@ -1,8 +1,11 @@
 const { Store, clone } = require('./store');
 
 class FlowMapper {
-  constructor(initialFlows = {}) {
-    this.store = new Store({ flows: clone(initialFlows) });
+  constructor(initialFlows = {}, initialGroups = {}) {
+    this.store = new Store({
+      flows: clone(initialFlows),
+      groups: clone(initialGroups),
+    });
   }
 
   addFlow(id, label = '') {
@@ -19,6 +22,43 @@ class FlowMapper {
     };
     this.store.setState({ flows });
     return flows[id];
+  }
+
+  addGroup(id, label = '', x = 0, y = 0) {
+    const groups = clone(this.store.getState().groups);
+    if (groups[id]) throw new Error(`Group ${id} already exists`);
+    groups[id] = { id, label, x, y, flows: [] };
+    this.store.setState({ groups });
+    return groups[id];
+  }
+
+  addFlowToGroup(flowId, groupId) {
+    const { flows, groups } = this.store.getState();
+    if (!flows[flowId]) throw new Error(`Flow ${flowId} missing`);
+    if (!groups[groupId]) throw new Error(`Group ${groupId} missing`);
+    if (!groups[groupId].flows.includes(flowId)) {
+      const next = clone(groups);
+      next[groupId].flows.push(flowId);
+      this.store.setState({ groups: next });
+    }
+  }
+
+  removeFlowFromGroup(flowId, groupId) {
+    const { groups } = this.store.getState();
+    if (!groups[groupId]) throw new Error(`Group ${groupId} missing`);
+    const next = clone(groups);
+    next[groupId].flows = next[groupId].flows.filter((f) => f !== flowId);
+    this.store.setState({ groups: next });
+  }
+
+  getGroup(id) {
+    return this.store.getState().groups[id];
+  }
+
+  getFlowsInGroup(groupId) {
+    const group = this.getGroup(groupId);
+    if (!group) throw new Error(`Group ${groupId} missing`);
+    return group.flows.map((id) => this.getFlow(id)).filter(Boolean);
   }
 
   setRole(flowId, role, value) {

--- a/canvas-store/flowMapper.test.js
+++ b/canvas-store/flowMapper.test.js
@@ -25,6 +25,15 @@ const assert = require('assert');
     'flow-3 should be incomplete'
   );
 
+  // group flows
+  mapper.addGroup('g1', 'Group 1');
+  mapper.addFlowToGroup('flow-1', 'g1');
+  assert.deepStrictEqual(mapper.getGroup('g1').flows, ['flow-1']);
+  mapper.addFlowToGroup('flow-2', 'g1');
+  assert.strictEqual(mapper.getFlowsInGroup('g1').length, 2);
+  mapper.removeFlowFromGroup('flow-1', 'g1');
+  assert.deepStrictEqual(mapper.getGroup('g1').flows, ['flow-2']);
+
   console.log('flowMapper tests passed');
 })();
 

--- a/node-edge/FlowCanvas.vue
+++ b/node-edge/FlowCanvas.vue
@@ -1,0 +1,62 @@
+<template>
+  <Canvas>
+    <div
+      v-for="group in groups"
+      :key="group.id"
+      class="group"
+      :style="{ left: group.x + 'px', top: group.y + 'px' }"
+    >
+      <header class="group-label">{{ group.label }}</header>
+      <div
+        v-for="flow in group.flows"
+        :key="flow"
+        class="flow"
+      >
+        {{ state.flows[flow]?.label || flow }}
+      </div>
+    </div>
+  </Canvas>
+</template>
+
+<script lang="ts">
+import { defineComponent, reactive, computed } from 'vue';
+import Canvas from './Canvas.vue';
+// FlowMapper uses CommonJS exports; most bundlers interop automatically.
+// @ts-ignore
+import { FlowMapper } from '../canvas-store/flowMapper.js';
+
+export default defineComponent({
+  name: 'FlowCanvas',
+  components: { Canvas },
+  setup() {
+    const mapper = new FlowMapper();
+    const state = reactive(mapper.store.getState());
+    mapper.store.subscribe((s: any) => Object.assign(state, s));
+    const groups = computed(() => Object.values(state.groups));
+    // expose API for parent components to manipulate flows/groups
+    return { state, mapper, groups };
+  },
+});
+</script>
+
+<style scoped>
+.group {
+  position: absolute;
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.group-label {
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+.flow {
+  background: #fff;
+  color: #000;
+  padding: 2px 4px;
+  margin-top: 2px;
+  border-radius: 2px;
+}
+</style>
+

--- a/node-edge/README.md
+++ b/node-edge/README.md
@@ -6,5 +6,6 @@ This directory contains a minimal extraction of the canvas components used for b
 
 - `Canvas.vue` – provides simple pan/zoom navigation similar to n8n's editor. Drag the background or use the mouse wheel to move around the canvas.
 - `CanvasEdge.vue` – renders bezier edges behind nodes with a non-scaling stroke to keep them flat.
+- `FlowCanvas.vue` – integrates the canvas-store `FlowMapper` so flows and groups can be managed reactively.
 
 Source code is adapted from the n8n project and is subject to the [Sustainable Use License](https://github.com/n8n-io/n8n/blob/master/packages/frontend/editor-ui/LICENSE.md).


### PR DESCRIPTION
## Summary
- extend FlowMapper to track groups with x/y coordinates and manage membership
- add FlowCanvas Vue component linking canvas view to FlowMapper state for flows and groups
- document and test new grouping capabilities

## Testing
- `node canvas-store/store.test.js`
- `node canvas-store/flowMapper.test.js`


------
https://chatgpt.com/codex/tasks/task_b_688efc5fc7a08332a97039517655a611