### PR TITLE
Add schema and AI instructions to JSON export

### DIFF
--- a/governance
+++ b/governance
@@ -1873,6 +1873,51 @@
                         exported: new Date().toISOString(),
                         theme: this.data.currentTheme
                     },
+                    schema: {
+                        metadata: {
+                            version: "string",
+                            exported: "ISO8601 timestamp string",
+                            theme: "string"
+                        },
+                        terminology: {
+                            appTitle: "string",
+                            rolesSection: "string",
+                            standardsSection: "string",
+                            permissionsSection: "string",
+                            responsibilities: "string",
+                            ownership: "string",
+                            roleColumn: "string",
+                            actionColumn: "string",
+                            taskColumn: "string",
+                            counterpartColumn: "string",
+                            actionTypes: {
+                                approves: "string",
+                                executes: "string",
+                                communicates: "string"
+                            }
+                        },
+                        roles: [
+                            {
+                                id: "number",
+                                name: "string",
+                                responsibilities: ["string"],
+                                ownership: ["string"]
+                            }
+                        ],
+                        standards: ["string"],
+                        permissions: [
+                            {
+                                id: "number",
+                                roleId: "number",
+                                action: ["approves", "executes", "communicates"],
+                                task: "string",
+                                counterpart: "string",
+                                status: "string",
+                                updated: "ISO date string (YYYY-MM-DD)"
+                            }
+                        ]
+                    },
+                    aiInstructions: "Convert natural language descriptions of team operations into a JSON object that matches the provided schema. Use exact property names, double quotes, arrays for lists, and ISO date formats. Return only valid JSON.",
                     terminology: this.data.terminology,
                     roles: this.data.roles,
                     standards: this.data.standards,


### PR DESCRIPTION
## Summary
- extend exportData to include a descriptive schema of the data structure
- embed instructions guiding AI to output properly formatted JSON

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688efd05afc88332bff547f8c5227246