### PR TITLE
Clarify housing metrics and ARPA impact

### DIFF
--- a/homelessness-metrics.html
+++ b/homelessness-metrics.html
@@ -468,7 +468,7 @@
                     <div class="metric-card">
                         <div class="metric-label">ROI Declining</div>
                         <div class="metric-value">95% more housed</div>
-                        <div class="metric-change">428% more spent (ops only)</div>
+                        <div class="metric-change">vs 428% more spent</div>
                     </div>
                 </div>
 
@@ -499,7 +499,8 @@
                 </div>
 
                 <div class="card" style="background: linear-gradient(135deg, rgba(251,191,36,0.05) 0%, rgba(255,255,255,1) 100%); border: 2px solid #f59e0b;">
-                    <h3 class="card-title">ARPA PSH Gap Financing: A Cracked Foundation</h3>
+                    <h3 class="card-title">124 PSH Units Funded Through ARPA</h3>
+                    <div class="chart-subtitle">Would house 8.4% of Nashville's 1,472 chronically unhoused people</div>
                     <div style="display: flex; align-items: center; gap: 2rem; margin-bottom: 1.5rem;">
                         <div style="flex: 1;">
                             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem;">


### PR DESCRIPTION
## Summary
- Present housing outcomes as a ratio by comparing 95% more placements to a 428% spending increase
- Highlight ARPA’s 124 PSH units and note they would house 8.4% of Nashville’s chronically unhoused

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a15992a53c8332833d270351166421