### PR TITLE
Show FY24 spend per housing unit with MDHA and OHS tags

### DIFF
--- a/homelessness-metrics.html
+++ b/homelessness-metrics.html
@@ -203,6 +203,17 @@
             margin-top: 0.25rem;
         }
 
+        .icon-tag {
+            display: inline-block;
+            background: var(--gray-200);
+            color: var(--gray-800);
+            border-radius: 0.25rem;
+            padding: 0 0.25rem;
+            margin-right: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+        }
+
         .chart-container {
             position: relative;
             margin: 0 auto 2rem auto;
@@ -467,8 +478,8 @@
                     </div>
                     <div class="metric-card">
                         <div class="metric-label">ROI Declining</div>
-                        <div class="metric-value">95% more housed</div>
-                        <div class="metric-change">428% more spent (ops only)</div>
+                        <div class="metric-value">$24,491/unit</div>
+                        <div class="metric-change"><span class="icon-tag">🏢 MDHA</span><span class="icon-tag">🏠 OHS</span> investing in building housing</div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Display FY24 spending per housing unit on the homelessness ROI card
- Add MDHA and OHS icon tags and supporting styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a15a404fe88332947b221bf65c08cb